### PR TITLE
Feature: Custom Goal Icons

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -20,6 +20,7 @@ export interface Application {
 export interface Goal {
   id: string
   name: string
+  icon: string | null
   targetAmount: number
   balance: number
   targetDate: Date

--- a/src/ui/components/EmojiPicker.tsx
+++ b/src/ui/components/EmojiPicker.tsx
@@ -3,7 +3,9 @@ import 'emoji-mart/css/emoji-mart.css'
 import { useAppSelector } from '../../store/hooks'
 import { selectMode } from '../../store/themeSlice'
 
-type Props = { onClick: (emoji: BaseEmoji, event: React.MouseEvent) => void }
+type Props = {
+  onClick: (emoji: BaseEmoji, event: React.MouseEvent) => void
+}
 
 export default function EmojiPicker(props: Props) {
   const theme = useAppSelector(selectMode)

--- a/src/ui/components/EmojiPicker.tsx
+++ b/src/ui/components/EmojiPicker.tsx
@@ -3,9 +3,7 @@ import 'emoji-mart/css/emoji-mart.css'
 import { useAppSelector } from '../../store/hooks'
 import { selectMode } from '../../store/themeSlice'
 
-type Props = {
-  onClick: (emoji: BaseEmoji, event: React.MouseEvent) => void
-}
+type Props = { onClick: (emoji: BaseEmoji, event: React.MouseEvent) => void }
 
 export default function EmojiPicker(props: Props) {
   const theme = useAppSelector(selectMode)

--- a/src/ui/pages/Main/goals/GoalCard.tsx
+++ b/src/ui/pages/Main/goals/GoalCard.tsx
@@ -5,11 +5,15 @@ import { useAppDispatch, useAppSelector } from '../../../../store/hooks'
 import {
   setContent as setContentRedux,
   setIsOpen as setIsOpenRedux,
-  setType as setTypeRedux
+  setType as setTypeRedux,
 } from '../../../../store/modalSlice'
 import { Card } from '../../../components/Card'
 
 type Props = { id: string }
+
+const Icon = styled.h1`
+  font-size: 5.5rem;
+`
 
 export default function GoalCard(props: Props) {
   const dispatch = useAppDispatch()
@@ -29,6 +33,7 @@ export default function GoalCard(props: Props) {
     <Container key={goal.id} onClick={onClick}>
       <TargetAmount>${goal.targetAmount}</TargetAmount>
       <TargetDate>{asLocaleDateString(goal.targetDate)}</TargetDate>
+      <Icon>{goal.icon}</Icon>
     </Container>
   )
 }


### PR DESCRIPTION
The user can now assign an icon for each goal. Click the "add icon" button at the bottom of a goal card to open an emoji picker. Select an emoji to set it as the icon for the goal.

**Added**
- Added goal icon support in `/ui/features/goalmanager/GoalManager.tsx`. Added `EmojiPicker` to support icon selection.

**Changed**
- Modified `Goal` interface at `/api/types.ts` to support goal icon.
- Modified `/ui/pages/Main/goals/GoalCard.tsx` component to support goal icon display.

**Note**
- The function for updating goal `updateGoal(goalId: string, updatedGoal: Goal)` already exists at `/api/lib.ts`